### PR TITLE
Update objreader.cc

### DIFF
--- a/VerStarting/objreader.cc
+++ b/VerStarting/objreader.cc
@@ -30,6 +30,16 @@ bool ObjFileReader::ReadMaterialLibrary(const char *line) {
     fprintf(stderr, "warning: unsupported mtllib format \"%s\"\n", line);
     return false;
   }
+  
+  char *cp = strrchr(line,'\r');
+  if(cp != nullptr){
+    *cp = '\0';
+  }
+	
+  cp = strrchr(line,'\n');
+  if(cp != nullptr){
+    *cp = '\0';
+  }
 
   std::string path = base_directory.empty() ? 
       fname :
@@ -495,6 +505,16 @@ bool MtlFileReader::ReadMtlFile(Scene *scene, const char *fname) {
     char line[128];
     if (fgets(line, sizeof(line), f.get()) == nullptr) {
       break;
+    }
+    
+    char *cp = strrchr(line,'\r');
+    if(cp != nullptr){
+      *cp = '\0';
+    }
+	
+    cp = strrchr(line,'\n');
+    if(cp != nullptr){
+      *cp = '\0';
     }
 
     char token[16]{};


### PR DESCRIPTION
Fix carriage return bug on linux
```
open("../Models/Living Room USSU Design.mtl\r", O_RDONLY) = -1 ENOENT (No such file or directory)
```